### PR TITLE
Add Android analytics tracking functionality

### DIFF
--- a/game/script.rpy
+++ b/game/script.rpy
@@ -168,6 +168,42 @@ python early:
     def show_rewarded_video():
         renpy.emscripten.run_script("showRewardedAd('reward_received');")
 
+init python:
+    import threading
+
+    def _send_android_analytics():
+        try:
+            if not renpy.android:
+                return
+
+            from jnius import autoclass
+
+            PythonSDLActivity = autoclass('org.renpy.android.PythonSDLActivity')
+            Settings = autoclass('android.provider.Settings$Secure')
+            context = PythonSDLActivity.mActivity
+            client_id = Settings.getString(
+                context.getContentResolver(), Settings.ANDROID_ID
+            )
+
+            try:
+                from urllib.request import Request, urlopen
+                from urllib.parse import urlencode
+            except ImportError:
+                from urllib2 import Request, urlopen
+                from urllib import urlencode
+
+            data = urlencode({
+                'clientId': client_id,
+                'group': 'khar'
+            }).encode('utf-8')
+
+            req = Request('https://khar.ttp3d.cn/counter.php', data=data)
+            urlopen(req, timeout=10)
+        except Exception:
+            pass
+
+    threading.Thread(target=_send_android_analytics, daemon=True).start()
+
 # Игра начинается здесь:
 
 screen game_over():


### PR DESCRIPTION
## Summary
Added Android-specific analytics tracking that sends device information to a remote server when the game runs on Android devices.

## Key Changes
- Implemented `_send_android_analytics()` function that:
  - Retrieves the device's unique Android ID using the Settings API
  - Sends analytics data (client ID and group identifier) to `https://khar.ttp3d.cn/counter.php`
  - Runs asynchronously in a daemon thread to avoid blocking game startup
  - Gracefully handles errors and skips execution on non-Android platforms
  - Includes Python 2/3 compatibility for urllib imports

## Implementation Details
- Uses JNIUS (Java Native Interface for Python) to access Android APIs
- Runs in a background daemon thread with a 10-second timeout to prevent hanging
- All exceptions are silently caught to ensure analytics failures don't impact gameplay
- Only executes when `renpy.android` is True, making it safe for other platforms
- Sends minimal data: device ID and a hardcoded group identifier ('khar')

https://claude.ai/code/session_01GUCHpTMxd6fyVTyHseZMFu