### PR TITLE
Fix About screen layout overflow

### DIFF
--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -819,6 +819,7 @@ style about_label_text:
 style about_text:
     size 26
     line_spacing 2
+    xsize 1000
 
 
 ## Экраны загрузки и сохранения ################################################


### PR DESCRIPTION
The "About" screen text was overflowing the screen horizontally because it lacked a width constraint. I added `xsize 1000` to the `about_text` style in `game/screens.rpy` to enable automatic text wrapping. The user indicated they already fixed the Russian translation issue, so no changes were made to the translation files.

---
*PR created automatically by Jules for task [5659292064475656449](https://jules.google.com/task/5659292064475656449) started by @Evsikoff*